### PR TITLE
Use JAXB plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.6-1</version> <!-- TODO use version from BOM when possible -->
+        </dependency>
+    </dependencies>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
JAXB has been removed from Java 9+, so use the JAXB Jenkins plugin to support running on those environments. CC @gcolin