### PR TITLE
[JENKINS-68470] Prepare Report Info for removal of JAXB and Java 11 requirement

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reportinfo/ReportInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/reportinfo/ReportInfo.java
@@ -65,7 +65,14 @@ public class ReportInfo extends ListView {
 
     static {
         try {
-            CONTEXT = JAXBContext.newInstance(JobNotification.class);
+            Thread t = Thread.currentThread();
+            ClassLoader orig = t.getContextClassLoader();
+            t.setContextClassLoader(ReportInfo.class.getClassLoader());
+            try {
+                CONTEXT = JAXBContext.newInstance(JobNotification.class);
+            } finally {
+                t.setContextClassLoader(orig);
+            }
         } catch (JAXBException ex) {
             LOG.log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
Amends #1. As discovered in https://github.com/jenkinsci/xcode-plugin/pull/113, it isn't enough just to add JAXB to the classpath. In order to accommodate the unusual [class loading system in Jenkins](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/), the thread's context class loader must be set to one that includes JAXB when invoking `JAXBContext.newInstance`. Tested successfully in the context of https://github.com/jenkinsci/xcode-plugin/pull/113 but not in the context of this plugin. CC @gcolin
